### PR TITLE
feat: added new labels including "first-timers-only" to gemfile

### DIFF
--- a/guide/legesher/labels/rename-labels.rb
+++ b/guide/legesher/labels/rename-labels.rb
@@ -55,6 +55,9 @@ default_labels = {
   "Language: Javascript" => "F48370",
   "Hacktoberfest" => "FF00AA",
   "Good First Issue" => "66CCFF"
+  "first-timers-only" => "E9EBF8"
+  "help wanted" => "E9EBF8"
+  "up-for-grabs" => "E9EBF8"
 }
 
 rename_labels = {
@@ -69,7 +72,6 @@ remove_labels = [
 	'wontfix',
 	'question',
 	'invalid',
-	'help wanted',
 	'duplicate',
 	'in progress',
 ]

--- a/guide/legesher/roadmap.md
+++ b/guide/legesher/roadmap.md
@@ -9,6 +9,7 @@ For issues in any repository, they follow the same conventions in terms of the l
 We group labels by color, according to broad themes. Labels are consistent across repositories, except for a few repository specific concepts. This is for the purpose of making the process of creating new issues and contributing to any repository in the Legesher portfolio easy and consistent.
 
 ### Opportunity Labels
+
 **Color**: Blue (#66CCFF)  
 `Opportunity: Copy`: for those who want to work on any thing copy-related  
 `Opportunity: Design`: for those who want to work on any thing design-related  
@@ -19,9 +20,10 @@ We group labels by color, according to broad themes. Labels are consistent acros
 `Opportunity: Great First Issue`: for those who don't know where to start  
 `Opportunity: Technical Beginner`: for those who have little to no technical experience  
 `Opportunity: Technical Intermediate`: for those who have some technical experience  
-`Opportunity: Technical Advanced`: for those who have familiarity with specific issues' technologies  
+`Opportunity: Technical Advanced`: for those who have familiarity with specific issues' technologies
 
 ### Status Labels
+
 **Color**: Yellow (#E9FF70)  
 `Status: Available`: the issue is available for sprint cleaning and delegation  
 `Status: Accepted`: the issue is accepted into an upcoming sprint  
@@ -36,9 +38,10 @@ We group labels by color, according to broad themes. Labels are consistent acros
 **Color**: Green (#70FF74)  
 `Status: Completed`: the issue has been completed  
 **Color**: Grey (#)  
-`Status: Abandoned`: the issue has been abandoned, may revisit at a later time  
+`Status: Abandoned`: the issue has been abandoned, may revisit at a later time
 
 ### Type Labels
+
 **Color**: Coral (#F48370)  
 `Type: Bug`: this issue is a bug related fix/issue  
 `Type: Epic`: this issue is a larger snapshot of a feature  
@@ -49,45 +52,61 @@ We group labels by color, according to broad themes. Labels are consistent acros
 `Type: Optimization`: this issue is to improve optimization  
 `Type: Maintenance`: this issue is for maintenance  
 `Type: Question`: this issue is a question  
-`Type: Feedback & Discussion`: this issue is marked for discussion  
+`Type: Feedback & Discussion`: this issue is marked for discussion
 
 ### Priority Labels
+
 **Color**: Purple (#D1A4FF)
 `Priority: Critical`: this issue is at the upmost importance and needs to be completed asap  
 `Priority: High`: this issue is to have top preference as the project cannot proceed without  
 `Priority: Medium`: this issue's resolution has a flexible or extended deadline  
-`Priority: Low`: this issue's resolution is non-immediate  
+`Priority: Low`: this issue's resolution is non-immediate
 
 ### Spoken Language Labels
+
 **Color**: Coral (#FF70A6)
 `Language: English`: English spoken language  
-`Language: Spanish`: Spanish spoken language  
+`Language: Spanish`: Spanish spoken language
 
 ### Programming Language Labels
+
 **Color**: Coral (#FF70A6)
 `Language: Python`: Python programming language  
-`Language: Javascript`: Javascript programming language  
+`Language: Javascript`: Javascript programming language
+
+### Universal Labels
+
+**Color**: Soft Blue (#E9EBF8)
+`first-timers-only`: Issues that welcome first-time contributors!
+`up-for-grabs`: Indicates the issue still needs an owner.
+`help wanted`: Indicates we want help on an issue or pull request.
 
 In order to update or add the labels to a new project repository, navigate to `legesher-docs/guide/legesher/labels` and run the command `ruby rename-labels.rb`.
 
 ## Becoming a Part of the Flock
+
 We love our people and we love empowering them to contribute what they know to push the project forward. We've attempted to make a simple flow for users who want to get more involved, to automate as much of the mundane process as possible.
 
 ### If you would like to contribute to the project
+
 ### If you would like to view the public roadmap
+
 We use ZenHub for our roadmap and sprint backlog. Unfortunately, the roadmap cannot be visible without being a member of the different repositories. The best way to receive access is to contribute to the project. Outside contributors will receive access as their email is readily available through github. You can also add your [email here](http://eepurl.com/dH0reL) to request access to the roadmap.
 
-
 ## Github Milestones
+
 For managing the Legesher project, sprints are described in GitHub as _milestones_. Each sprint is 2-weeks comprised of around 80 story points (as the project progresses thus number may fluctuate).
 
 ### The Sprint Syntax
+
 The sprint syntax follows the syntax: `Sprint [START_DATE]` where the START_DATE follows the date format MM/DD/YY.
 
 ### Story Points
+
 Each issue when it is accepted into the current sprint will be given story points. These serve as an estimate of the amount of work that it will take to complete the specific issue. As time progresses, our estimate of how long each issue will take will improve. 1 & 2 story points permit a small change that might include a waiting period, but very little work. 40 story points is a large undertaking and consuming the majority of a contributor's time.
 
 ## Epics
+
 Epics are described as larger feature goals that are set for the project. Epics are usually comprised of multiple issues that all feed into the epic's completion. These have their own label `Epic`.
 
 For example, one of our current epics include [Preparing for Open Source Release](https://github.com/legesher/legesher/issues/1). On Github it looks like a normal issue with another label, but within the ZenHub project management tool it contains a snapshot of all the issues that are associated with the epic, current status of all of the issues as well as their story point estimations.
@@ -96,24 +115,27 @@ This is what it might look like on ZenHub:
 <img src="/lib/images/ZenHubEpicView.png" align="center"/>
 
 ## Pipelines
+
 Within the ZenHub Project Management tool, the issues are then organized into pipelines depending on the status of the issue.
 
 - `New Issues`: When issues are created they first reside here
-- `Epic`: Where all the major Epics live  
-- `Incubator`: In the icebox - issues/features that are +6 months out  
-- `Development Backlog`: Work that is sprint-ready, but not yet accepted and planned into the upcoming Milestone  
-- `Sprint Backlog`: Work that has been committed to, and accepted into the upcoming Sprint  
-- `In Progress`: For items that are in the current sprint  
-- `Review/QA`: For items that are waiting approval  
-- `Done`: Issues that have been completed within the specific sprint.  
-- `Closed`: When issues are completed they go here  
+- `Epic`: Where all the major Epics live
+- `Incubator`: In the icebox - issues/features that are +6 months out
+- `Development Backlog`: Work that is sprint-ready, but not yet accepted and planned into the upcoming Milestone
+- `Sprint Backlog`: Work that has been committed to, and accepted into the upcoming Sprint
+- `In Progress`: For items that are in the current sprint
+- `Review/QA`: For items that are waiting approval
+- `Done`: Issues that have been completed within the specific sprint.
+- `Closed`: When issues are completed they go here
 
 ## Releases
+
 Releases are the larger moments that the public are aware of. When a new version of a software is released, it is included in a "Release". Some may be a patches because a certain bug was found to full on version upgrades.
 
 ## Assignees
+
 On each issue an individual or team of people will be assigned when it is added to a Milestone/Sprint. If you are assigned to the issue it is your responsibility to complete the assignment. As always, we are more than willing to help and involve the community as best as you can - even documenting your thought process along the way. If you would like to be assigned to the issue and help solve the issue, please comment on the issue and take the initiative. We love that!! ❤️
 
-  - We have contributor guidelines that are to ensure you're not wasting your time with mundane tasks and additionally so we maintain consistency across the project. When you have contributed to the project, we would like to honor you and thank you for your contribution. When your contribution is accepted, you will receive instructions to receive your gift. 🎁
+- We have contributor guidelines that are to ensure you're not wasting your time with mundane tasks and additionally so we maintain consistency across the project. When you have contributed to the project, we would like to honor you and thank you for your contribution. When your contribution is accepted, you will receive instructions to receive your gift. 🎁
 
 [Take a look at our current contributors here]()


### PR DESCRIPTION
Added the following labels to the gemfile: 
- `first-timers-only`
- `up-for-grabs`
- `help wanted`

Set a common colour, and updated the documentation to reflect a new category called "Universal Labels". 
Addresses issue #20. 

**Reviewers be aware**
The `help wanted` label was previously being removed automatically, I stripped this line from the auto-removal piece of the code. Hope that's okay. 